### PR TITLE
Support nghttp2_session_get_last_proc_stream_id

### DIFF
--- a/ext/ds9/ds9.c
+++ b/ext/ds9/ds9.c
@@ -696,6 +696,19 @@ static VALUE session_submit_shutdown(VALUE self)
     return explode(rv);
 }
 
+static VALUE session_get_last_proc_stream_id(VALUE self)
+{
+    int rv;
+    nghttp2_session *session;
+
+    TypedData_Get_Struct(self, nghttp2_session, &ds9_session_type, session);
+    CheckSelf(session);
+
+    rv = nghttp2_session_get_last_proc_stream_id(session);
+
+    return INT2NUM(rv);
+}
+
 static VALUE session_submit_goaway(VALUE self, VALUE last_stream_id, VALUE err)
 {
     int rv;
@@ -996,6 +1009,7 @@ void Init_ds9(void)
     rb_define_method(cDS9Session, "stream_local_closed?", session_stream_local_closed_p, 1);
     rb_define_method(cDS9Session, "stream_remote_closed?", session_stream_remote_closed_p, 1);
     rb_define_method(cDS9Session, "resume_data", session_resume_data, 1);
+    rb_define_method(cDS9Session, "last_proc_stream_id", session_get_last_proc_stream_id, 0);
 
     rb_define_private_method(cDS9Session, "submit_request", session_submit_request, 2);
     rb_define_private_method(cDS9Session, "make_callbacks", make_callbacks, 0);


### PR DESCRIPTION
Support  [nghttp2_session_get_last_proc_stream_id](https://nghttp2.org/documentation/nghttp2_session_get_last_proc_stream_id.html#c.nghttp2_session_get_last_proc_stream_id).
we use it for performing a graceful shutdown. 

https://tools.ietf.org/html/rfc7540#section-6.8

> A client that is unable to retry requests loses all requests that are
   in flight when the server closes the connection.  This is especially
   true for intermediaries that might not be serving clients using
   HTTP/2.  A server that is attempting to gracefully shut down a
   connection SHOULD send an initial GOAWAY frame with the last stream
   identifier set to 2^31-1 and a NO_ERROR code.  This signals to the
   client that a shutdown is imminent and that initiating further
   requests is prohibited.  After allowing time for any in-flight stream
   creation (at least one round-trip time), the server can send another
   GOAWAY frame with an updated last stream identifier.  This ensures
   that a connection can be cleanly shut down without losing requests.
