### PR TITLE
Get goaway frame field

### DIFF
--- a/ext/ds9/ds9_frames.c
+++ b/ext/ds9/ds9_frames.c
@@ -108,6 +108,14 @@ static VALUE header_category(VALUE self)
     return INT2NUM(frame->headers.cat);
 }
 
+static VALUE goaway_last_stream_id(VALUE self)
+{
+    nghttp2_frame *frame;
+    TypedData_Get_Struct(self, nghttp2_frame, &ds9_frame_type, frame);
+
+    return INT2NUM(frame->goaway.last_stream_id);
+}
+
 void Init_ds9_frames(VALUE mDS9)
 {
     mDS9Frames = rb_define_module_under(mDS9, "Frames");
@@ -140,6 +148,7 @@ void Init_ds9_frames(VALUE mDS9)
     rb_define_const(mDS9FramesFlags, "PADDED", INT2NUM(NGHTTP2_FLAG_PADDED));
     rb_define_const(mDS9FramesFlags, "PRIORITY", INT2NUM(NGHTTP2_FLAG_PRIORITY));
 
+    rb_define_method(cDS9FramesGoaway, "last_stream_id", goaway_last_stream_id, 0);
     rb_define_const(cDS9FramesGoaway, "NO_ERROR", INT2NUM(NGHTTP2_NO_ERROR));
     rb_define_const(cDS9FramesGoaway, "PROTOCOL_ERROR", INT2NUM(NGHTTP2_PROTOCOL_ERROR));
     rb_define_const(cDS9FramesGoaway, "INTERNAL_ERROR", INT2NUM(NGHTTP2_INTERNAL_ERROR));

--- a/ext/ds9/ds9_frames.c
+++ b/ext/ds9/ds9_frames.c
@@ -116,6 +116,14 @@ static VALUE goaway_last_stream_id(VALUE self)
     return INT2NUM(frame->goaway.last_stream_id);
 }
 
+static VALUE goaway_error_code(VALUE self)
+{
+    nghttp2_frame *frame;
+    TypedData_Get_Struct(self, nghttp2_frame, &ds9_frame_type, frame);
+
+    return INT2NUM(frame->goaway.error_code);
+}
+
 void Init_ds9_frames(VALUE mDS9)
 {
     mDS9Frames = rb_define_module_under(mDS9, "Frames");
@@ -149,6 +157,7 @@ void Init_ds9_frames(VALUE mDS9)
     rb_define_const(mDS9FramesFlags, "PRIORITY", INT2NUM(NGHTTP2_FLAG_PRIORITY));
 
     rb_define_method(cDS9FramesGoaway, "last_stream_id", goaway_last_stream_id, 0);
+    rb_define_method(cDS9FramesGoaway, "error_code", goaway_error_code, 0);
     rb_define_const(cDS9FramesGoaway, "NO_ERROR", INT2NUM(NGHTTP2_NO_ERROR));
     rb_define_const(cDS9FramesGoaway, "PROTOCOL_ERROR", INT2NUM(NGHTTP2_PROTOCOL_ERROR));
     rb_define_const(cDS9FramesGoaway, "INTERNAL_ERROR", INT2NUM(NGHTTP2_INTERNAL_ERROR));


### PR DESCRIPTION
Support last_stream_id and error_code of goaway frame.

https://nghttp2.org/documentation/types.html#c.nghttp2_goaway.last_stream_id
https://nghttp2.org/documentation/types.html#c.nghttp2_goaway.error_code

ref: https://github.com/tenderlove/ds9/pull/3