### PR TITLE
Add sever_submit_headers

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -205,6 +205,10 @@ module DS9
           stream.submit_response stream_id, headers
         end
 
+        def submit_headers headers
+          stream.submit_headers stream_id, headers
+        end
+
         def finish str
           body << str
           body << nil

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -1,0 +1,68 @@
+require 'helper'
+
+class TestServer < DS9::TestCase
+  def test_submit_response
+    server, client = pipe do |req, res|
+      refute req.stream.stream_remote_closed?(req.stream_id)
+      refute req.stream.stream_local_closed?(req.stream_id)
+      res.submit_response([[':status', '200'],
+                           ['server', 'test server'],
+                           ['date', 'Sat, 27 Jun 2015 17:29:21 GMT']])
+      res.finish('omglol')
+    end
+
+    s = Thread.new { server.run }
+    c = Thread.new { client.run }
+
+    client.submit_request([[':method', 'GET'],
+                           [':path', '/'],
+                           [':scheme', 'https'],
+                           [':authority', ['localhost', '8080'].join(':')],
+                           ['accept', '*/*'],
+                           ['user-agent', 'test']])
+
+    responses = []
+    while (response = client.responses.pop)
+      responses << response
+      if responses.length == 1
+        client.terminate_session DS9::NO_ERROR
+      end
+    end
+
+    s.join
+    c.join
+    assert_equal ['omglol'], responses.map(&:body).map(&:string)
+  end
+
+  def test_submit_headers
+    server, client = pipe do |req, res|
+      refute req.stream.stream_remote_closed?(req.stream_id)
+      refute req.stream.stream_local_closed?(req.stream_id)
+      res.submit_headers([[':status', '200'],
+                          ['server', 'test server'],
+                          ['date', 'Sat, 27 Jun 2015 17:29:21 GMT']])
+    end
+
+    s = Thread.new { server.run }
+    c = Thread.new { client.run }
+
+    client.submit_request([[':method', 'GET'],
+                           [':path', '/'],
+                           [':scheme', 'https'],
+                           [':authority', ['localhost', '8080'].join(':')],
+                           ['accept', '*/*'],
+                           ['user-agent', 'test']])
+
+    responses = []
+    while (response = client.responses.pop)
+      responses << response
+      if responses.length == 1
+        client.terminate_session DS9::NO_ERROR
+      end
+    end
+
+    s.join
+    c.join
+    assert_equal [''], responses.map(&:body).map(&:string)
+  end
+end


### PR DESCRIPTION
This change allows users to send a response without DATA frame. This feature is acheived by using `nghttp2_submit_response` with `data_body` is NULL as https://nghttp2.org/documentation/nghttp2_submit_response.html described.

> If data_prd is not NULL, it provides data which will be sent in subsequent DATA frames. This function does not take ownership of the data_prd. The function copies the members of the data_prd. If data_prd is NULL, HEADERS will have END_STREAM flag set.

I made a decision not to use `nghttp2_submit_headers` to implment it because https://nghttp2.org/documentation/nghttp2_submit_headers.html says like blow. And I believe in `nghttp2_submit_response` is enough for just sending a response without DATA frame.

> This function is low-level in a sense that the application code can specify flags directly. For usual HTTP request, nghttp2_submit_request() is useful. Likewise, for HTTP response, prefer nghttp2_submit_response().

