### PR TITLE
Return NGHTTP2_ERR_DEFERRED  directly

### DIFF
--- a/ext/ds9/ds9.c
+++ b/ext/ds9/ds9.c
@@ -595,8 +595,11 @@ ruby_read(nghttp2_session *session, int32_t stream_id, uint8_t *buf, size_t leng
 	rb_funcall(self, rb_intern("remove_post_buffer"), 1, INT2NUM(stream_id));
 	*data_flags |= NGHTTP2_DATA_FLAG_EOF;
 	return 0;
-    } else if (ret == Qfalse) {
-      return NGHTTP2_ERR_DEFERRED;
+    } else if (FIXNUM_P(ret)) {
+        ssize_t err = NUM2INT(ret);
+        if (err == NGHTTP2_ERR_DEFERRED) {
+            return err;
+        }
     } else {
 	memcpy(buf, RSTRING_PTR(ret), RSTRING_LEN(ret));
 	return RSTRING_LEN(ret);

--- a/ext/ds9/ds9.c
+++ b/ext/ds9/ds9.c
@@ -283,6 +283,13 @@ static ssize_t rb_data_read_callback(nghttp2_session *session,
 	return 0;
     }
 
+    if (FIXNUM_P(ret)) {
+        ssize_t err = NUM2INT(ret);
+        if (err == NGHTTP2_ERR_DEFERRED) {
+            return err;
+        }
+    }
+
     Check_Type(ret, T_STRING);
     len = RSTRING_LEN(ret);
     memcpy(buf, StringValuePtr(ret), len);
@@ -975,6 +982,7 @@ void Init_ds9(void)
 
     rb_define_const(mDS9, "ERR_WOULDBLOCK", INT2NUM(NGHTTP2_ERR_WOULDBLOCK));
     rb_define_const(mDS9, "ERR_EOF", INT2NUM(NGHTTP2_ERR_EOF));
+    rb_define_const(mDS9, "ERR_DEFERRED", INT2NUM(NGHTTP2_ERR_DEFERRED));
     rb_define_const(mDS9, "NO_ERROR", INT2NUM(NGHTTP2_NO_ERROR));
     rb_define_const(mDS9, "DEFAULT_WEIGHT", INT2NUM(NGHTTP2_DEFAULT_WEIGHT));
     rb_define_const(mDS9, "MAX_WEIGHT", INT2NUM(NGHTTP2_MAX_WEIGHT));

--- a/ext/ds9/ds9.c
+++ b/ext/ds9/ds9.c
@@ -600,10 +600,11 @@ ruby_read(nghttp2_session *session, int32_t stream_id, uint8_t *buf, size_t leng
         if (err == NGHTTP2_ERR_DEFERRED) {
             return err;
         }
-    } else {
-	memcpy(buf, RSTRING_PTR(ret), RSTRING_LEN(ret));
-	return RSTRING_LEN(ret);
     }
+
+    Check_Type(ret, T_STRING);
+    memcpy(buf, RSTRING_PTR(ret), RSTRING_LEN(ret));
+    return RSTRING_LEN(ret);
 }
 
 static ssize_t


### PR DESCRIPTION
To postpone DATA frame in server and client,  I made`DS9::Server#on_data_source_read` and `Object#read` (which is passed in `DS9::Session#submit_request`) be able to return `NGHTTP2_ERR_DEFERRED` directly.

ref: https://nghttp2.org/documentation/types.html#c.nghttp2_data_source_read_callback

> If the application wants to postpone DATA frames (e.g., asynchronous I/O, or reading data blocks for long time), it is achieved by returning NGHTTP2_ERR_DEFERRED without reading any data in this invocation. The library removes DATA frame from the outgoing queue temporarily. To move back deferred DATA frame to outgoing queue, call nghttp2_session_resume_data().
