### PR TITLE
require rake/testtask to add task "test" to rake command

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require "bundler/gem_tasks"
 require "rake/extensiontask"
+require "rake/testtask"
 
 task default: :compile
 
@@ -7,6 +8,11 @@ Rake::ExtensionTask.new("ds9") do |t|
   t.name = "ds9"
   t.ext_dir = "ext/ds9"
   t.lib_dir = "lib"
+end
+
+Rake::TestTask.new('test' => 'compile') do |t|
+  t.libs << 'test'
+  t.verbose = true
 end
 
 # vim: syntax=ruby


### PR DESCRIPTION
To work a code `bundle exec rake compile test` in README.md, I added a code to require `"rake/testtask"`.