### PR TITLE
Support passing nghttp2_option 

### DIFF
--- a/ext/ds9/ds9.h
+++ b/ext/ds9/ds9.h
@@ -4,6 +4,7 @@
 #include <ruby.h>
 #include <ruby/io.h>
 #include <nghttp2/nghttp2.h>
+#include <ds9_option.h>
 
 static const rb_data_type_t ds9_session_type = {
     "DS9/session",

--- a/ext/ds9/ds9_option.c
+++ b/ext/ds9/ds9_option.c
@@ -1,0 +1,153 @@
+#include <ds9_option.h>
+
+VALUE cDS9Option;
+
+static VALUE allocate_option(VALUE klass)
+{
+    nghttp2_option *option;
+
+    nghttp2_option_new(&option);
+
+    return TypedData_Wrap_Struct(klass, &ds9_option_type, option);
+}
+
+static VALUE option_set_no_auto_ping_ack(VALUE self)
+{
+    nghttp2_option *option;
+    TypedData_Get_Struct(self, nghttp2_option, &ds9_option_type, option);
+
+    nghttp2_option_set_no_auto_ping_ack(option, 1);
+
+    return self;
+}
+
+static VALUE option_set_no_auto_window_update(VALUE self)
+{
+    nghttp2_option *option;
+    TypedData_Get_Struct(self, nghttp2_option, &ds9_option_type, option);
+
+    nghttp2_option_set_no_auto_window_update(option, 1);
+
+    return self;
+}
+
+static VALUE option_set_no_closed_streams(VALUE self)
+{
+    nghttp2_option *option;
+    TypedData_Get_Struct(self, nghttp2_option, &ds9_option_type, option);
+
+    nghttp2_option_set_no_closed_streams(option, 1);
+
+    return self;
+}
+
+static VALUE option_set_no_http_messaging(VALUE self)
+{
+    nghttp2_option *option;
+    TypedData_Get_Struct(self, nghttp2_option, &ds9_option_type, option);
+
+    nghttp2_option_set_no_http_messaging(option, 1);
+
+    return self;
+}
+
+static VALUE option_set_no_recv_client_magic(VALUE self)
+{
+    nghttp2_option *option;
+    TypedData_Get_Struct(self, nghttp2_option, &ds9_option_type, option);
+
+    nghttp2_option_set_no_recv_client_magic(option, 1);
+
+    return self;
+}
+
+
+static VALUE option_set_builtin_recv_extension_type(VALUE self, VALUE size)
+{
+    nghttp2_option *option;
+    TypedData_Get_Struct(self, nghttp2_option, &ds9_option_type, option);
+
+    nghttp2_option_set_builtin_recv_extension_type(option, NUM2INT(size));
+
+    return self;
+}
+
+static VALUE option_set_max_deflate_dynamic_table_size(VALUE self, VALUE size)
+{
+    nghttp2_option *option;
+    TypedData_Get_Struct(self, nghttp2_option, &ds9_option_type, option);
+
+    nghttp2_option_set_max_deflate_dynamic_table_size(option, NUM2INT(size));
+
+    return self;
+}
+
+static VALUE option_set_max_send_header_block_length(VALUE self, VALUE size)
+{
+    nghttp2_option *option;
+    TypedData_Get_Struct(self, nghttp2_option, &ds9_option_type, option);
+
+    nghttp2_option_set_max_send_header_block_length(option, NUM2INT(size));
+
+    return self;
+}
+
+static VALUE option_set_max_reserved_remote_streams(VALUE self, VALUE size)
+{
+    nghttp2_option *option;
+    TypedData_Get_Struct(self, nghttp2_option, &ds9_option_type, option);
+
+    nghttp2_option_set_max_reserved_remote_streams(option, NUM2INT(size));
+
+    return self;
+}
+
+static VALUE option_set_peer_max_concurrent_streams(VALUE self, VALUE size)
+{
+    nghttp2_option *option;
+    TypedData_Get_Struct(self, nghttp2_option, &ds9_option_type, option);
+
+    nghttp2_option_set_peer_max_concurrent_streams(option, NUM2INT(size));
+
+    return self;
+}
+
+static VALUE option_set_user_recv_extension_type(VALUE self, VALUE size)
+{
+    nghttp2_option *option;
+    TypedData_Get_Struct(self, nghttp2_option, &ds9_option_type, option);
+
+    nghttp2_option_set_user_recv_extension_type(option, NUM2INT(size));
+
+    return self;
+}
+
+nghttp2_option* UnwrapDS9Option(VALUE opt)
+{
+    nghttp2_option* option = NULL;
+
+    if (!NIL_P(opt)) {
+	TypedData_Get_Struct(opt, nghttp2_option, &ds9_option_type, option);
+    }
+
+    return option;
+}
+
+void Init_ds9_option(VALUE mDS9)
+{
+    cDS9Option = rb_define_class_under(mDS9, "Option", rb_cData);
+    rb_define_alloc_func(cDS9Option, allocate_option);
+
+    rb_define_method(cDS9Option, "set_no_auto_ping_ack", option_set_no_auto_ping_ack, 0);
+    rb_define_method(cDS9Option, "set_no_auto_window_update", option_set_no_auto_window_update, 0);
+    rb_define_method(cDS9Option, "set_no_closed_streams", option_set_no_closed_streams, 0);
+    rb_define_method(cDS9Option, "set_no_http_messaging", option_set_no_http_messaging, 0);
+    rb_define_method(cDS9Option, "set_no_recv_client_magic", option_set_no_recv_client_magic, 0);
+
+    rb_define_method(cDS9Option, "set_builtin_recv_extension_type", option_set_builtin_recv_extension_type, 1);
+    rb_define_method(cDS9Option, "set_max_deflate_dynamic_table_size", option_set_max_deflate_dynamic_table_size, 1);
+    rb_define_method(cDS9Option, "set_max_send_header_block_length", option_set_max_send_header_block_length, 1);
+    rb_define_method(cDS9Option, "set_max_reserved_remote_streams", option_set_max_reserved_remote_streams, 1);
+    rb_define_method(cDS9Option, "set_peer_max_concurrent_streams", option_set_peer_max_concurrent_streams, 1);
+    rb_define_method(cDS9Option, "set_user_recv_extension_type", option_set_user_recv_extension_type, 1);
+}

--- a/ext/ds9/ds9_option.h
+++ b/ext/ds9/ds9_option.h
@@ -1,0 +1,19 @@
+#ifndef DS9_OPTION_H
+#define DS9_OPTION_H
+
+#include <ruby.h>
+#include <nghttp2/nghttp2.h>
+
+static const rb_data_type_t ds9_option_type = {
+    "DS9/option",
+    {0, (void (*)(void *))nghttp2_option_del, 0,},
+    0, 0,
+#ifdef RUBY_TYPED_FREE_IMMEDIATELY
+    RUBY_TYPED_FREE_IMMEDIATELY,
+#endif
+};
+
+void Init_ds9_option(VALUE mDS9);
+nghttp2_option* UnwrapDS9Option(VALUE opt);
+
+#endif

--- a/lib/ds9.rb
+++ b/lib/ds9.rb
@@ -75,10 +75,11 @@ module DS9
   end
 
   class Session
-    def initialize
+    # @param option [DS9::Option]
+    def initialize(option: nil)
       @post_buffers = {}
       cbs = make_callbacks
-      init_internals cbs
+      init_internals(cbs, option)
     end
 
     private

--- a/test/test_ds9_option.rb
+++ b/test/test_ds9_option.rb
@@ -1,0 +1,87 @@
+require 'helper'
+
+class TestMeme < Minitest::Test
+  def setup
+    @option = DS9::Option.new
+  end
+
+  def test_set_no_auto_ping_ack
+    assert @option.set_no_auto_ping_ack
+  end
+
+  def test_set_no_auto_window_update
+    assert @option.set_no_auto_window_update
+  end
+
+  def test_set_no_closed_streams
+    assert @option.set_no_closed_streams
+  end
+
+  def test_set_no_http_messaging
+    assert @option.set_no_http_messaging
+  end
+
+  def test_set_no_recv_client_magic
+    assert @option.set_no_recv_client_magic
+  end
+
+  def test_set_builtin_recv_extension_type
+    assert @option.set_builtin_recv_extension_type(1)
+  end
+
+  def test_set_builtin_recv_extension_type_with_not_num
+    assert_raises TypeError do
+      assert @option.set_builtin_recv_extension_type('invalid')
+    end
+  end
+
+  def test_set_max_deflate_dynamic_table_size
+    assert @option.set_max_deflate_dynamic_table_size(1)
+  end
+
+  def test_set_max_deflate_dynamic_table_size_with_not_num
+    assert_raises TypeError do
+      @option.set_max_deflate_dynamic_table_size('invalid')
+    end
+  end
+
+  def test_set_max_send_header_block_length
+    assert @option.set_max_send_header_block_length(1)
+  end
+
+  def test_set_max_send_header_block_length_with_not_num
+    assert_raises TypeError do
+      assert @option.set_max_send_header_block_length('invalid')
+    end
+  end
+
+  def test_set_max_reserved_remote_streams
+    assert @option.set_max_reserved_remote_streams(100)
+  end
+
+  def test_set_max_reserved_remote_streams_not_num
+    assert_raises TypeError do
+      @option.set_max_reserved_remote_streams('invalid')
+    end
+  end
+
+  def test_set_peer_max_concurrent_streams
+    assert @option.set_peer_max_concurrent_streams(1)
+  end
+
+  def test_set_peer_max_concurrent_stream_with_not_num
+    assert_raises TypeError do
+      assert @option.set_peer_max_concurrent_streams('invalid')
+    end
+  end
+
+  def test_set_user_recv_extension_type
+    assert @option.set_user_recv_extension_type(1)
+  end
+
+  def test_set_user_recv_extension_type_with_not_num
+    assert_raises TypeError do
+      assert @option.set_user_recv_extension_type('invalid')
+    end
+  end
+end


### PR DESCRIPTION
 I made it possible for users to change the setting of [nghttp2_option](https://nghttp2.org/documentation/types.html#c.nghttp2_option) since I'd like to use the option like [no_closed_streams](https://nghttp2.org/documentation/nghttp2_option_set_no_closed_streams.html) which would decrease the memory usage in [grpc_kit](https://github.com/ganmacs/grpc_kit). 

