### PR TITLE
Build nghttp2 without python bindings

### DIFF
--- a/ext/ds9/extconf.rb
+++ b/ext/ds9/extconf.rb
@@ -24,7 +24,7 @@ else
   require 'rubygems'
   require 'mini_portile2'
   recipe = MiniPortile.new('nghttp2', 'v1.34.0')
-  recipe.configure_options = recipe.configure_options + ['--with-pic']
+  recipe.configure_options = recipe.configure_options + ['--with-pic', '--disable-python-bindings']
 
   recipe.files << {
     url: 'https://github.com/nghttp2/nghttp2/releases/download/v1.34.0/nghttp2-1.34.0.tar.gz',


### PR DESCRIPTION
ds9 is a wrapper for nghttp2, therefore building with python bindings is unnecessary. Users in certain environments have difficulty with building the python bindings, e.g. when using multiple pythons via pyenv.

As noted in https://github.com/tenderlove/ds9/pull/12#issuecomment-536962914 I think it would be better to use `--enable-lib-only`, but I'm not clear as to why @ganmacs chose to remove the option.

I'm proposing this as a minimal change that solves the problems that I've encountered.


