### PR TITLE
Build with nghttp --enable-lib-only

### DIFF
--- a/ext/ds9/extconf.rb
+++ b/ext/ds9/extconf.rb
@@ -24,7 +24,7 @@ else
   require 'rubygems'
   require 'mini_portile2'
   recipe = MiniPortile.new('nghttp2', 'v1.34.0')
-  recipe.configure_options = recipe.configure_options + ['--with-pic', '--disable-python-bindings']
+  recipe.configure_options = recipe.configure_options + ['--with-pic', '--enable-lib-only']
 
   recipe.files << {
     url: 'https://github.com/nghttp2/nghttp2/releases/download/v1.34.0/nghttp2-1.34.0.tar.gz',


### PR DESCRIPTION
Quick follow-up to #16 

The nghttp2 README recommends using --enable-lib-only if only
libnghttp2 is required, as is the case with ds9.

Note that --enable-lib-only is short hand for
--disable-app --disable-examples --disable-hpack-tools --disable-python-bindings

@ganmacs 😄 