### PR TITLE
Add bindings for new nghttp2 options

### DIFF
--- a/ext/ds9/ds9_option.c
+++ b/ext/ds9/ds9_option.c
@@ -134,6 +134,18 @@ static VALUE option_set_max_outbound_ack(VALUE self, VALUE size)
 }
 #endif
 
+#if NGHTTP2_VERSION_NUM >= 0x012900 /* 1.41.0 */
+static VALUE option_set_max_settings(VALUE self, VALUE size)
+{
+    nghttp2_option *option;
+    TypedData_Get_Struct(self, nghttp2_option, &ds9_option_type, option);
+
+    nghttp2_option_set_max_settings(option, NUM2INT(size));
+
+    return self;
+}
+#endif
+
 nghttp2_option* UnwrapDS9Option(VALUE opt)
 {
     nghttp2_option* option = NULL;
@@ -164,5 +176,8 @@ void Init_ds9_option(VALUE mDS9)
     rb_define_method(cDS9Option, "set_user_recv_extension_type", option_set_user_recv_extension_type, 1);
 #if NGHTTP2_VERSION_NUM >= 0x012800 /* 1.40.0 */
     rb_define_method(cDS9Option, "set_max_outbound_ack", option_set_max_outbound_ack, 1);
+#endif
+#if NGHTTP2_VERSION_NUM >= 0x012900 /* 1.41.0 */
+    rb_define_method(cDS9Option, "set_max_settings", option_set_max_settings, 1);
 #endif
 }

--- a/ext/ds9/ds9_option.c
+++ b/ext/ds9/ds9_option.c
@@ -122,6 +122,18 @@ static VALUE option_set_user_recv_extension_type(VALUE self, VALUE size)
     return self;
 }
 
+#if NGHTTP2_VERSION_NUM >= 0x012800 /* 1.40.0 */
+static VALUE option_set_max_outbound_ack(VALUE self, VALUE size)
+{
+    nghttp2_option *option;
+    TypedData_Get_Struct(self, nghttp2_option, &ds9_option_type, option);
+
+    nghttp2_option_set_max_outbound_ack(option, NUM2INT(size));
+
+    return self;
+}
+#endif
+
 nghttp2_option* UnwrapDS9Option(VALUE opt)
 {
     nghttp2_option* option = NULL;
@@ -150,4 +162,7 @@ void Init_ds9_option(VALUE mDS9)
     rb_define_method(cDS9Option, "set_max_reserved_remote_streams", option_set_max_reserved_remote_streams, 1);
     rb_define_method(cDS9Option, "set_peer_max_concurrent_streams", option_set_peer_max_concurrent_streams, 1);
     rb_define_method(cDS9Option, "set_user_recv_extension_type", option_set_user_recv_extension_type, 1);
+#if NGHTTP2_VERSION_NUM >= 0x012800 /* 1.40.0 */
+    rb_define_method(cDS9Option, "set_max_outbound_ack", option_set_max_outbound_ack, 1);
+#endif
 }

--- a/ext/ds9/extconf.rb
+++ b/ext/ds9/extconf.rb
@@ -23,12 +23,12 @@ else
   message "Building nghttp2\n"
   require 'rubygems'
   require 'mini_portile2'
-  recipe = MiniPortile.new('nghttp2', 'v1.34.0')
+  recipe = MiniPortile.new('nghttp2', 'v1.43.0')
   recipe.configure_options = recipe.configure_options + ['--with-pic', '--enable-lib-only']
 
   recipe.files << {
-    url: 'https://github.com/nghttp2/nghttp2/releases/download/v1.34.0/nghttp2-1.34.0.tar.gz',
-    sha1: '2d0ad93a254a7a6e6c737f2fd2e10e4810a41f74',
+    url: 'https://github.com/nghttp2/nghttp2/releases/download/v1.43.0/nghttp2-1.43.0.tar.gz',
+    sha1: '8686c8ceee769de8b9e304739b223981df9df104',
   }
   recipe.cook
 

--- a/test/test_ds9_option.rb
+++ b/test/test_ds9_option.rb
@@ -94,4 +94,14 @@ class TestMeme < Minitest::Test
       assert @option.set_max_outbound_ack('invalid')
     end
   end
+
+  def test_set_max_settings
+    assert @option.set_max_settings(16)
+  end
+
+  def test_set_max_settings_with_not_num
+    assert_raises TypeError do
+      assert @option.set_max_settings('invalid')
+    end
+  end
 end

--- a/test/test_ds9_option.rb
+++ b/test/test_ds9_option.rb
@@ -84,4 +84,14 @@ class TestMeme < Minitest::Test
       assert @option.set_user_recv_extension_type('invalid')
     end
   end
+
+  def test_set_max_outbound_ack
+    assert @option.set_max_outbound_ack(100)
+  end
+
+  def test_set_max_outbound_ack_with_not_num
+    assert_raises TypeError do
+      assert @option.set_max_outbound_ack('invalid')
+    end
+  end
 end


### PR DESCRIPTION
I'd like to add bindings for the following two options nghttp2 library provides:

- [nghttp2_option_set_max_outbound_ack](https://nghttp2.org/documentation/nghttp2_option_set_max_outbound_ack.html)
    - https://github.com/nghttp2/nghttp2/commit/0a6ce87c22c69438ecbffe52a2859c3a32f1620f introduced the option.
- [nghttp2_option_set_max_settings](https://nghttp2.org/documentation/nghttp2_option_set_max_settings.html):
    - https://github.com/nghttp2/nghttp2/commit/336a98feb0d56b9ac54e12736b18785c27f75090 introduced the option.