### PR TITLE
Fix compiler warnings when building C extension

### DIFF
--- a/ext/ds9/ds9.c
+++ b/ext/ds9/ds9.c
@@ -157,7 +157,7 @@ static ssize_t recv_callback(nghttp2_session *session, uint8_t *buf,
     VALUE ret;
     ssize_t len;
 
-    ret = rb_funcall(self, id_recv_event, 1, INT2NUM(length));
+    ret = rb_funcall(self, id_recv_event, 1, ULONG2NUM(length));
 
     if (FIXNUM_P(ret)) {
 	return NUM2INT(ret);
@@ -270,7 +270,7 @@ static ssize_t rb_data_read_callback(nghttp2_session *session,
     ssize_t len;
 
     ret = rb_funcall(self, id_on_data_source_read, 2, INT2NUM(stream_id),
-	    INT2NUM(length));
+	    ULONG2NUM(length));
 
     if (NIL_P(ret)) {
 	*data_flags |= NGHTTP2_DATA_FLAG_EOF;
@@ -553,7 +553,7 @@ static VALUE session_mem_receive(VALUE self, VALUE buf)
 	explode((int)rv);
     }
 
-    return INT2NUM(rv);
+    return ULONG2NUM(rv);
 }
 
 static VALUE session_mem_send(VALUE self)
@@ -585,14 +585,14 @@ static VALUE session_outbound_queue_size(VALUE self)
     TypedData_Get_Struct(self, nghttp2_session, &ds9_session_type, session);
     CheckSelf(session);
 
-    return INT2NUM(nghttp2_session_get_outbound_queue_size(session));
+    return ULONG2NUM(nghttp2_session_get_outbound_queue_size(session));
 }
 
 static ssize_t
 ruby_read(nghttp2_session *session, int32_t stream_id, uint8_t *buf, size_t length,
     uint32_t *data_flags, nghttp2_data_source *source, void *user_data)
 {
-    VALUE ret = rb_funcall((VALUE)source->ptr, rb_intern("read"), 1, INT2NUM(length));
+    VALUE ret = rb_funcall((VALUE)source->ptr, rb_intern("read"), 1, ULONG2NUM(length));
 
     if (NIL_P(ret)) {
 	VALUE self = (VALUE)user_data;

--- a/ext/ds9/ds9.c
+++ b/ext/ds9/ds9.c
@@ -490,6 +490,7 @@ static VALUE session_submit_trailer(VALUE self, VALUE stream_id, VALUE trailers)
 	    break;
 	default:
 	    Check_Type(trailers, T_ARRAY);
+	    UNREACHABLE;
     }
 
     nva = xcalloc(niv, sizeof(nghttp2_nv));
@@ -658,6 +659,7 @@ static VALUE session_submit_request(VALUE self, VALUE settings, VALUE body)
 	    break;
 	default:
 	    Check_Type(settings, T_ARRAY);
+	    UNREACHABLE;
     }
 
     nva = xcalloc(niv, sizeof(nghttp2_nv));
@@ -849,6 +851,7 @@ static VALUE server_submit_response(VALUE self, VALUE stream_id, VALUE headers)
 	    break;
 	default:
 	    Check_Type(headers, T_ARRAY);
+	    UNREACHABLE;
     }
 
     nva = xcalloc(niv, sizeof(nghttp2_nv));
@@ -890,6 +893,7 @@ static VALUE server_submit_headers(VALUE self, VALUE stream_id, VALUE headers) {
 	    break;
 	default:
 	    Check_Type(headers, T_ARRAY);
+	    UNREACHABLE;
     }
 
     nva = xcalloc(niv, sizeof(nghttp2_nv));

--- a/ext/ds9/ds9.c
+++ b/ext/ds9/ds9.c
@@ -635,8 +635,8 @@ file_read(nghttp2_session *session, int32_t stream_id, uint8_t *buf, size_t leng
 
 static VALUE session_submit_request(VALUE self, VALUE settings, VALUE body)
 {
-    size_t niv, i;
-    nghttp2_nv *nva, *head;
+    size_t niv;
+    nghttp2_nv *nva;
     nghttp2_session *session;
     nghttp2_data_provider provider;
     int rv;
@@ -828,7 +828,7 @@ static VALUE server_submit_response(VALUE self, VALUE stream_id, VALUE headers)
 {
     nghttp2_session *session;
     size_t niv;
-    nghttp2_nv *nva, *head;
+    nghttp2_nv *nva;
     nghttp2_data_provider provider;
     int rv;
     copy_header_func_t copy_func;
@@ -870,7 +870,7 @@ static VALUE server_submit_response(VALUE self, VALUE stream_id, VALUE headers)
 static VALUE server_submit_headers(VALUE self, VALUE stream_id, VALUE headers) {
     nghttp2_session *session;
     size_t niv;
-    nghttp2_nv *nva, *head;
+    nghttp2_nv *nva;
     int rv;
     copy_header_func_t copy_func;
 

--- a/ext/ds9/ds9.c
+++ b/ext/ds9/ds9.c
@@ -1048,7 +1048,7 @@ void Init_ds9(void)
 
     rb_define_singleton_method(mDS9, "nghttp_version", rb_nghttp_version, 0);
 
-    cDS9Callbacks = rb_define_class_under(mDS9, "Callbacks", rb_cData);
+    cDS9Callbacks = rb_define_class_under(mDS9, "Callbacks", rb_cObject);
 
     cDS9Session = rb_define_class_under(mDS9, "Session", rb_cObject);
     cDS9Client = rb_define_class_under(mDS9, "Client", cDS9Session);


### PR DESCRIPTION
This PR fixes the following compiler warnings when building the C extension:

cc7d187

```
../../../../ext/ds9/ds9.c:638:17: warning: unused variable 'i' [-Wunused-variable]
    size_t niv, i;
                ^
../../../../ext/ds9/ds9.c:639:23: warning: unused variable 'head' [-Wunused-variable]
    nghttp2_nv *nva, *head;
                      ^
```

592ee70

```
../../../../ext/ds9/ds9.c:344:27: warning: incompatible pointer types passing 'int (VALUE, VALUE, struct hash_copy_ctx *)' (aka 'int (unsigned long, unsigned long, struct hash_copy_ctx *)') to parameter of type 'int (*)(VALUE, VALUE, VALUE)' (aka 'int (*)(unsigned long, unsigned long, unsigned long)') [-Wincompatible-pointer-types]
    rb_hash_foreach(hash, hash_copy_i, &copy_ctx);
                          ^~~~~~~~~~~
../../../../ext/ds9/ds9.c:344:40: warning: incompatible pointer to integer conversion passing 'struct hash_copy_ctx *' to parameter of type 'VALUE' (aka 'unsigned long') [-Wint-conversion]
    rb_hash_foreach(hash, hash_copy_i, &copy_ctx);
                                       ^~~~~~~~~
../../../../ext/ds9/ds9.c:549:10: warning: implicit conversion loses integer precision: 'ssize_t' (aka 'long') to 'int' [-Wshorten-64-to-32]
    rv = nghttp2_session_mem_recv(session, (const uint8_t *)StringValuePtr(buf), RSTRING_LEN(buf));
       ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../../ext/ds9/ds9.c:573:10: warning: implicit conversion loses integer precision: 'ssize_t' (aka 'long') to 'int' [-Wshorten-64-to-32]
        explode(rv);
        ~~~~~~~ ^~
../../../../ext/ds9/ds9.c:593:28: warning: incompatible pointer to integer conversion passing 'void *' to parameter of type 'VALUE' (aka 'unsigned long')
      [-Wint-conversion]
    VALUE ret = rb_funcall(source->ptr, rb_intern("read"), 1, INT2NUM(length));
                           ^~~~~~~~~~~
../../../../ext/ds9/ds9.c:676:26: warning: incompatible integer to pointer conversion assigning to 'void *' from 'VALUE' (aka 'unsigned long')
      [-Wint-conversion]
            provider.source.ptr = body;
                                ^ ~~~~
```

fd4ad47

```
../../../../ext/ds9/ds9.c:490:2: warning: variable 'niv' is used uninitialized whenever switch default is taken [-Wsometimes-uninitialized]
        default:
        ^~~~~~~
../../../../ext/ds9/ds9.c:490:2: warning: variable 'copy_func' is used uninitialized whenever switch default is taken [-Wsometimes-uninitialized]
        default:
        ^~~~~~~
```

f72b6c4

```
../../../../ext/ds9/ds9.c:160:54: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]
    ret = rb_funcall(self, id_recv_event, 1, INT2NUM(length));
                                             ~~~~~~~ ^~~~~~
```

96e8691

```
../../../../ext/ds9/ds9.c:1046:62: warning: 'rb_cData' is deprecated: by: rb_cObject. Will be removed in 3.1. [-Wdeprecated-declarations]
    cDS9Callbacks = rb_define_class_under(mDS9, "Callbacks", rb_cData);
                                                             ^
```