### PR TITLE
Fix compiler warnings when building C extension

### DIFF
--- a/ext/ds9/ds9_frames.c
+++ b/ext/ds9/ds9_frames.c
@@ -45,7 +45,7 @@ VALUE WrapDS9FrameHeader(const nghttp2_frame_hd *hd)
 {
     VALUE klass = rb_const_get(cDS9FramesFrame, rb_intern("Header"));
     return rb_funcall(klass, rb_intern("new"), 4,
-	    INT2NUM(hd->length),
+	    ULONG2NUM(hd->length),
 	    INT2NUM(hd->stream_id),
 	    INT2NUM(hd->type),
 	    INT2NUM(hd->flags));

--- a/ext/ds9/ds9_frames.c
+++ b/ext/ds9/ds9_frames.c
@@ -127,7 +127,7 @@ static VALUE goaway_error_code(VALUE self)
 void Init_ds9_frames(VALUE mDS9)
 {
     mDS9Frames = rb_define_module_under(mDS9, "Frames");
-    cDS9FramesFrame = rb_define_class_under(mDS9Frames, "Frame", rb_cData);
+    cDS9FramesFrame = rb_define_class_under(mDS9Frames, "Frame", rb_cObject);
 
     mDS9FramesFlags = rb_define_module_under(cDS9FramesFrame, "Flags");
 

--- a/ext/ds9/ds9_option.c
+++ b/ext/ds9/ds9_option.c
@@ -159,7 +159,7 @@ nghttp2_option* UnwrapDS9Option(VALUE opt)
 
 void Init_ds9_option(VALUE mDS9)
 {
-    cDS9Option = rb_define_class_under(mDS9, "Option", rb_cData);
+    cDS9Option = rb_define_class_under(mDS9, "Option", rb_cObject);
     rb_define_alloc_func(cDS9Option, allocate_option);
 
     rb_define_method(cDS9Option, "set_no_auto_ping_ack", option_set_no_auto_ping_ack, 0);


### PR DESCRIPTION
This PR fixes the following compiler warnings in ds9_frames.c and ds9_option.c, which I missed in #19.

e5bac91

```
../../../../ext/ds9/ds9_frames.c:130:66: warning: 'rb_cData' is deprecated: by: rb_cObject. Will be removed in 3.1. [-Wdeprecated-declarations]
    cDS9FramesFrame = rb_define_class_under(mDS9Frames, "Frame", rb_cData);
                                                                 ^
../../../../ext/ds9/ds9_option.c:162:56: warning: 'rb_cData' is deprecated: by: rb_cObject. Will be removed in 3.1. [-Wdeprecated-declarations]
    cDS9Option = rb_define_class_under(mDS9, "Option", rb_cData);
                                                       ^
```

5fe4b25

```
../../../../ext/ds9/ds9_frames.c:48:18: warning: implicit conversion loses integer precision: 'const size_t' (aka 'const unsigned long') to 'int' [-Wshorten-64-to-32]
            INT2NUM(hd->length),
            ~~~~~~~ ~~~~^~~~~~
```